### PR TITLE
Change type of dyno from web to worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+worker: npm start


### PR DESCRIPTION
A web dyno requires you to bind the port but since we are not binding to a port it will crash. This fixes that